### PR TITLE
km-viewingAnnotations / Issue 11 - Viewing annotation content

### DIFF
--- a/src/Components/Duration.js
+++ b/src/Components/Duration.js
@@ -1,0 +1,26 @@
+import React from 'react'
+
+/* Credit to CookPete and tarhan. Found in CookPete's ReactPlayer demo here: https://github.com/CookPete/react-player/blob/master/src/demo/Duration.js */
+
+export default function Duration ({ className, seconds }) {
+  return (
+    <time dateTime={`P${Math.round(seconds)}S`} className={className}>
+      {format(seconds)}
+    </time>
+  )
+}
+
+function format (seconds) {
+  const date = new Date(seconds * 1000)
+  const hh = date.getUTCHours()
+  const mm = date.getUTCMinutes()
+  const ss = pad(date.getUTCSeconds())
+  if (hh) {
+    return `${hh}:${pad(mm)}:${ss}`
+  }
+  return `${mm}:${ss}`
+}
+
+function pad (string) {
+  return ('0' + string).slice(-2)
+}

--- a/src/Components/css/Player.css
+++ b/src/Components/css/Player.css
@@ -38,7 +38,7 @@
     grid-area: getTimestamp;
 }
 
-#timestamp {
+.timestamp {
     padding-left: 2px;
     grid-area: timestamp;
 }

--- a/src/Components/videos/NoteCard.js
+++ b/src/Components/videos/NoteCard.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import Duration from '../Duration'
+
+const NoteCard = props => {
+
+    return (
+        <section>
+            <Duration seconds={props.displayNote.timestamp} />
+            <h1>{props.displayNote.noteTitle}</h1>
+            <p>{props.displayNote.noteContent}</p>
+        </section>
+
+    )
+}
+
+export default NoteCard


### PR DESCRIPTION
### Added:
• Duration.js
- Borrowed from CookPete's ReactPlayer demo repo. Handles storing of seconds and converting it into machine readable HTML time tags recognized as durations. Also makes them human readable.

• NoteCard.js - note content component

• played state

• displayNote state to hold annotation content. Setting of displayNote determined by played state. 

### Changed:
• Removed the old way I saved and displayed timestamps and replaced it using the clearer Duration component from CookPete's ReactPlayer demo